### PR TITLE
#5 classpath-string->jar refactor to accept a map instead of limited manifest fields

### DIFF
--- a/src/mach/pack/alpha/capsule.clj
+++ b/src/mach/pack/alpha/capsule.clj
@@ -41,7 +41,7 @@
   (Paths/get first (into-array String more)))
 
 (defn classpath-string->jar
-  [classpath-string jar-location application-id application-version main]
+  [classpath-string jar-location manifest]
   (let [classpath
         (map io/file (split-classpath-string classpath-string))]
     (spit-jar!
@@ -67,12 +67,7 @@
                              io/file)))
                 classpath)
               [["Capsule.class" (io/resource "Capsule.class")]])
-      (cond->
-        [["Application-Class" "clojure.main"]
-         ["Application-ID" application-id]
-         ["Application-Version" application-version]]
-        main
-        (conj ["Args" (str "-m " main)]))
+      manifest
       "Capsule")))
 
 (def ^:private cli-options
@@ -135,7 +130,11 @@
                                 (paths-get [%]))
               (:paths deps-map))
             {:extra-paths extra-path})
-          output
-          application-id
-          application-version
-          main)))))
+
+          (cond->
+              [["Application-Class" "clojure.main"]
+               ["Application-ID" application-id]
+               ["Application-Version" application-version]]
+            main
+            (conj ["Args" (str "-m " main)])))))))
+


### PR DESCRIPTION
This is a first step towards making capsule packaging a bit more extensible.

By refactoring `classpath-string->jar function` to accept a map instead of few enumerated fields it's possible now to extend resulting manifest with additional fields, eg. related to caplets.

Next step would be, I guess, to pass desired fields (like `Caplets`) through command line arguments and assoc them into a map (in `-main`) which is passed now to `classpath-string->jar function`.