### PR TITLE
Add missing argument passed to: capsule/classpath-string->jar

### DIFF
--- a/src/mach/pack/alpha/capsule.clj
+++ b/src/mach/pack/alpha/capsule.clj
@@ -130,7 +130,7 @@
                                 (paths-get [%]))
               (:paths deps-map))
             {:extra-paths extra-path})
-
+          output
           (cond->
               [["Application-Class" "clojure.main"]
                ["Application-ID" application-id]


### PR DESCRIPTION
mach.pack.alpha.capsule/-main call to mach.pack.alpha.capsule/classpath-string->jar was missing the output jar path argument as describe below.
```
Exception in thread "main" clojure.lang.ArityException: Wrong number of args (2) passed to: capsule/classpath-string->jar
	at clojure.lang.AFn.throwArity(AFn.java:429)
	at clojure.lang.AFn.invoke(AFn.java:36)
	at mach.pack.alpha.capsule$_main.invokeStatic(capsule.clj:127)
	at mach.pack.alpha.capsule$_main.doInvoke(capsule.clj:104)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.core$apply.invokeStatic(core.clj:657)
	at clojure.main$main_opt.invokeStatic(main.clj:317)
	at clojure.main$main_opt.invoke(main.clj:313)
	at clojure.main$main.invokeStatic(main.clj:424)
	at clojure.main$main.doInvoke(main.clj:387)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.main.main(main.java:37)
```