### PR TITLE
Added Capsule CLI opts for JVM args and System Properties.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,8 @@ Options:
   -m, --main SYMBOL                           main namespace
       --application-id STRING                 globally unique name for application, used for caching
       --application-version STRING            unique version for this uberjar, used for caching
+      --system-properties STRING              space-separated list of propName=value pairs, specifying JVM System Properties which will be passed to the application. Maps to the 'System-Properties' entry in the Capsule Manifest.
+      --jvm-args STRING                       space-separated list of JVM argument that will be used to launch the application (e.g "-server -Xms200m -Xmx600m"). Maps to the 'JVM-Args' entry in the Capsule Manifest.
   -e, --extra-path STRING                     add directory to classpath for building
   -d, --deps STRING                 deps.edn  deps.edn file location
   -h, --help                                  show this help

--- a/src/mach/pack/alpha/capsule.clj
+++ b/src/mach/pack/alpha/capsule.clj
@@ -75,6 +75,8 @@
     :parse-fn symbol]
    [nil "--application-id STRING" "globally unique name for application, used for caching"]
    [nil "--application-version STRING" "unique version for this uberjar, used for caching"]
+   [nil "--system-properties STRING" "space-separated list of propName=value pairs, specifying JVM System Properties which will be passed to the application. Maps to the 'System-Properties' entry in the Capsule Manifest."]
+   [nil "--jvm-args STRING" "space-separated list of JVM argument that will be used to launch the application (e.g \"-server -Xms200m -Xmx600m\"). Maps to the 'JVM-Args' entry in the Capsule Manifest."]
    ["-e" "--extra-path STRING" "add directory to classpath for building"
     :assoc-fn (fn [m k v] (update m k conj v))]
    ["-d" "--deps STRING" "deps.edn file location"
@@ -108,6 +110,8 @@
                  main
                  application-id
                  application-version
+                 system-properties
+                 jvm-args
                  help]} :options
          [output] :arguments
          :as parsed-opts}
@@ -135,6 +139,10 @@
               [["Application-Class" "clojure.main"]
                ["Application-ID" application-id]
                ["Application-Version" application-version]]
+            system-properties
+            (conj ["System-Properties" system-properties])
+            jvm-args
+            (conj ["JVM-Args" jvm-args])
             main
             (conj ["Args" (str "-m " main)])))))))
 


### PR DESCRIPTION
These options are especially useful for tuning the application JVM process without affecting the Capsule launcher process.