### PR TITLE
Added Capsule -M / --manifest-entry CLI opt for conveying arbitrary C…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,12 +50,12 @@ $ java -jar uberjar.jar
 [source]
 ----
 Usage: clj -m mach.pack.alpha.capsule [options] <path/to/output.jar>
-Options:
   -m, --main SYMBOL                           main namespace
       --application-id STRING                 globally unique name for application, used for caching
       --application-version STRING            unique version for this uberjar, used for caching
   -e, --extra-path STRING                     add directory to classpath for building
   -d, --deps STRING                 deps.edn  deps.edn file location
+  -M, --manifest-entry STRING                 a "Key: Value" pair that will be appended to the Capsule Manifest; useful for conveying arbitrary Manifest entries to the Capsule Manifest. Can be repeated to supply several entries.
   -h, --help                                  show this help
 ----
 

--- a/src/mach/pack/alpha/capsule.clj
+++ b/src/mach/pack/alpha/capsule.clj
@@ -70,6 +70,13 @@
       manifest
       "Capsule")))
 
+(def manifest-header-pattern
+  ;; see https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html
+  ;; NOTE: we're being slightly more liberal than the spec, which is OK since
+  ;; we're only interested in breaking the supplied Manifest entry into a [name value] pair;
+  ;; further validation will happen downstream at the java.util.jar/Manifest level. (Valentin Waeselynck, 23 Jun 2018)
+  #"([a-zA-Z0-9_\-]+):\s(.*)")
+
 (def ^:private cli-options
   [["-m" "--main SYMBOL" "main namespace"
     :parse-fn symbol]
@@ -80,6 +87,13 @@
    ["-d" "--deps STRING" "deps.edn file location"
     :default "deps.edn"
     :validate [(comp (memfn exists) io/file) "deps.edn file must exist"]]
+   ["-M" "--manifest-entry STRING"
+    "a \"Key: Value\" pair that will be appended to the Capsule Manifest; useful for conveying arbitrary Manifest entries to the Capsule Manifest. Can be repeated to supply several entries."
+    :validate [(fn [arg] (re-matches manifest-header-pattern arg))
+               "Manifest Entry must be of the form \"Name: Value\" (whitespace matters)"]
+    :assoc-fn (fn [m opt arg]
+                (let [[_ k v] (re-matches manifest-header-pattern arg)]
+                  (update m opt #(-> % (or []) (conj [k v])))))]
    ["-h" "--help" "show this help"]])
 
 (defn- usage
@@ -108,6 +122,7 @@
                  main
                  application-id
                  application-version
+                 manifest-entry
                  help]} :options
          [output] :arguments
          :as parsed-opts}
@@ -136,5 +151,7 @@
                ["Application-ID" application-id]
                ["Application-Version" application-version]]
             main
-            (conj ["Args" (str "-m " main)])))))))
+            (conj ["Args" (str "-m " main)])
+            true
+            (into manifest-entry)))))))
 


### PR DESCRIPTION
Although #12 already adds some useful options for filling the Capsule Manifest, there are other such Manifest entries that Pack may not have anticipated.

In the Clojure / EDN spirit of "don't impose unnecessary knowledge on the intermediaries", I think it's valuable to enable the user to pass arbitrary options through Pack to the Capsule Manifest.