### PR TITLE
Allow specifying alias to use for classpath for uberjar

### DIFF
--- a/src/mach/pack/alpha/capsule.clj
+++ b/src/mach/pack/alpha/capsule.clj
@@ -71,6 +71,10 @@
       manifest
       "Capsule")))
 
+(defn merge-aliases [deps-map aliases]
+  (let [alias-keys (map #(keyword (str ":" %)) (string/split aliases #":"))]
+    alias-keys))
+
 (def manifest-header-pattern
   ;; see https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html
   ;; NOTE: we're being slightly more liberal than the spec, which is OK since
@@ -144,7 +148,7 @@
       (println (error-msg errors))
       :else
       (let [deps-map (tools.deps.reader/slurp-deps (io/file deps))]
-        (pprint deps-map)
+        (pprint (merge-aliases deps-map alias))
         (classpath-string->jar
           (tools.deps/make-classpath
             (tools.deps/resolve-deps deps-map nil)

--- a/src/mach/pack/alpha/capsule.clj
+++ b/src/mach/pack/alpha/capsule.clj
@@ -8,6 +8,7 @@
    [clojure.tools.deps.alpha.reader :as tools.deps.reader]
    [mach.pack.alpha.impl.assembly :refer [spit-jar!]]
    [mach.pack.alpha.impl.elodin :as elodin]
+   [clojure.pprint :refer [pprint]]
    [me.raynes.fs :as fs])
   (:import
    java.io.File
@@ -89,6 +90,7 @@
    ["-d" "--deps STRING" "deps.edn file location"
     :default "deps.edn"
     :validate [(comp (memfn exists) io/file) "deps.edn file must exist"]]
+   ["-a" "--alias" "Aliases to use for determining extra dependencies"]
    ["-M" "--manifest-entry STRING"
     "a \"Key: Value\" pair that will be appended to the Capsule Manifest; useful for conveying arbitrary Manifest entries to the Capsule Manifest. Can be repeated to supply several entries."
     :validate [(fn [arg] (re-matches manifest-header-pattern arg))
@@ -120,6 +122,7 @@
 (defn -main
   [& args]
   (let [{{:keys [deps
+                 alias
                  extra-path
                  main
                  application-id
@@ -141,6 +144,7 @@
       (println (error-msg errors))
       :else
       (let [deps-map (tools.deps.reader/slurp-deps (io/file deps))]
+        (pprint deps-map)
         (classpath-string->jar
           (tools.deps/make-classpath
             (tools.deps/resolve-deps deps-map nil)


### PR DESCRIPTION
Related issue: https://github.com/juxt/pack.alpha/issues/16

Adds a CLI option for specifying aliases to use to resolve dependencies:

`clj -A:pack mach.pack.alpha.capsule -a :server:dev uberjar.jar ...`

or

`clj -A:pack mach.pack.alpha.capsule --alias :server:dev uberjar.jar ...`