### PR TITLE
Fix write-all receiving nil project-config or lib-config

### DIFF
--- a/src/mach/pack/alpha/skinny.clj
+++ b/src/mach/pack/alpha/skinny.clj
@@ -84,8 +84,10 @@
 
 (defn write-all
   [x project-config lib-config]
-  (write-project x project-config)
-  (write-libs x lib-config))
+  (when project-config
+    (write-project x project-config))
+  (when lib-config
+    (write-libs x lib-config)))
 
 (def ^:private cli-options
   (concat


### PR DESCRIPTION
The function should not perform the side effects in case those parameters are
nil.