### PR TITLE
Lambda zip - fix arity error calling elodin/directory-name

### DIFF
--- a/src/mach/pack/alpha/aws_lambda.clj
+++ b/src/mach/pack/alpha/aws_lambda.clj
@@ -21,11 +21,11 @@
         (lib-map/lib-jars lib-map))
 
       (map
-        (fn [{:keys [path lib]}]
+        (fn [{:keys [path lib] :as all}]
           {:paths (vfs/files-path
                     (file-seq (io/file path))
                     (io/file path))
-           :path ["lib" (format "%s.jar" (elodin/directory-name))]})
+           :path ["lib" (format "%s.jar" (elodin/directory-name all))]})
         (lib-map/lib-dirs lib-map))
 
       (mapcat


### PR DESCRIPTION
Hey JUXTers :)

Quick arity error fix calling through to `elodin/directory-name` in the Lambda packaging - have verified on our internal lambda deploys but let me know if there's anything else I can do.

Cheers,

James 