### PR TITLE
Support building Docker images

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -238,3 +238,24 @@ Future calls to `pom.xml` won't change them back.
 ----
 mvn deploy:deploy-file -Dfile=my-cool-lib.jar -DrepositoryId=clojars -Durl=https://clojars.org/repo -DpomFile=pom.xml
 ----
+
+=== Docker image
+
+Create a Docker image via link:https://github.com/GoogleContainerTools/jib[Jib]. Supports building to local Docker daemon (`--image-type docker`), tarball (`--image-type tar`) and uploading to Docker registries authenticated via `$USER_HOME/.docker/config.json` (`--image-type registry`).
+
+[source]
+----
+Usage: clj -m mach.pack.alpha.jib [options]
+
+Options:
+      --image-name NAME                                   Name of the image
+      --image-type TYPE        :docker                    Type of the image, one of: tar, registry, docker
+      --tar-file FILE                                     Tarball file name
+      --base-image BASE-IMAGE  gcr.io/distroless/java:11  Base Docker image to use
+  -m, --main SYMBOL                                       Main namespace
+  -A ALIASES                                              Concatenated aliases of any kind, ex: -A:dev:mem
+  -R ALIASES                                              Concatenated resolve-deps aliases, ex: -R:bench:1.9
+  -C ALIASES                                              Concatenated make-classpath aliases, ex: -C:dev
+  -e, --extra-path STRING                                 Add directory to classpath for building. Same as :extra-paths
+  -h, --help                                              show this help
+----

--- a/README.adoc
+++ b/README.adoc
@@ -252,6 +252,8 @@ Options:
       --image-type TYPE        :docker                    Type of the image, one of: tar, registry, docker
       --tar-file FILE                                     Tarball file name
       --base-image BASE-IMAGE  gcr.io/distroless/java:11  Base Docker image to use
+  -q, --quiet                                             Don't print a progress bar
+  -v, --verbose                                           Print status of image building
   -m, --main SYMBOL                                       Main namespace
   -A ALIASES                                              Concatenated aliases of any kind, ex: -A:dev:mem
   -R ALIASES                                              Concatenated resolve-deps aliases, ex: -R:bench:1.9

--- a/README.adoc
+++ b/README.adoc
@@ -252,6 +252,7 @@ Options:
       --image-type TYPE        :docker                    Type of the image, one of: tar, registry, docker
       --tar-file FILE                                     Tarball file name
       --base-image BASE-IMAGE  gcr.io/distroless/java:11  Base Docker image to use
+      --include [src:]dest                                Include file or directory, relative to container root
   -q, --quiet                                             Don't print a progress bar
   -v, --verbose                                           Print status of image building
   -m, --main SYMBOL                                       Main namespace

--- a/README.adoc
+++ b/README.adoc
@@ -259,3 +259,10 @@ Options:
   -e, --extra-path STRING                                 Add directory to classpath for building. Same as :extra-paths
   -h, --help                                              show this help
 ----
+
+For example, to deploy to Google Container Registry, first perform link:https://cloud.google.com/container-registry/docs/advanced-authentication[authentication] and then specify registry, repository and tag in the image name:
+
+[source]
+----
+clj -A:pack mach.pack.alpha.jib --image-name eu.gcr.io/my-example-project/my-app:1234 --image-type registry -m my.main
+----

--- a/deps.edn
+++ b/deps.edn
@@ -3,4 +3,5 @@
         me.raynes/fs {:mvn/version "1.4.6"}
         co.paralleluniverse/capsule {:mvn/version "1.0.3"}
         org.clojure/tools.cli {:mvn/version "0.4.1"}
-        rewrite-clj {:mvn/version "0.6.0"}}}
+        rewrite-clj {:mvn/version "0.6.0"}
+        com.google.cloud.tools/jib-core {:mvn/version "0.10.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,4 +4,5 @@
         co.paralleluniverse/capsule {:mvn/version "1.0.3"}
         org.clojure/tools.cli {:mvn/version "0.4.1"}
         rewrite-clj {:mvn/version "0.6.0"}
-        com.google.cloud.tools/jib-core {:mvn/version "0.10.0"}}}
+        com.google.cloud.tools/jib-core {:mvn/version "0.10.0"}
+        progrock {:mvn/version "0.1.2"}}}

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -1,0 +1,75 @@
+(ns mach.pack.alpha.jib
+  (:require [mach.pack.alpha.impl.tools-deps :as tools-deps]
+            [mach.pack.alpha.impl.lib-map :as lib-map]
+            [clojure.string :as str]
+            [clojure.tools.cli :as cli]
+            [mach.pack.alpha.impl.elodin :as elodin])
+  (:import (com.google.cloud.tools.jib.api Jib AbsoluteUnixPath)
+           (java.nio.file Paths)
+           (com.google.cloud.tools.jib.api LayerConfiguration
+                                           LayerConfiguration$Builder
+                                           Containerizer
+                                           DockerDaemonImage)))
+
+(defn jib [{::tools-deps/keys [lib-map]} {:keys [image-name base-image target-dir]}]
+  (println "Building" image-name)
+  (let [libs-layer (.build (reduce (fn [acc {:keys [path] :as all}]
+                                     (.addEntry acc
+                                                (Paths/get path (into-array String []))
+                                                (AbsoluteUnixPath/get (str target-dir
+                                                                           "/"
+                                                                           (elodin/versioned-lib all)
+                                                                           ".jar"))))
+                                   (LayerConfiguration/builder)
+                                   (lib-map/lib-jars lib-map)))]
+    (-> (Jib/from base-image)
+        (.addLayer libs-layer)
+        (.setEntrypoint (into-array String ["java" "-cp" (str target-dir "/*") "clojure.main"]))
+        (.containerize (Containerizer/to (DockerDaemonImage/named image-name))))))
+
+(def ^:private cli-options
+  (concat
+   [[nil "--image-name IMAGE" "Name of image to build for docker daemon"]
+    [nil "--base-image BASE-IMAGE" "Base Docker image to use"
+     :default "openjdk:11-jre-slim"]
+    [nil "--target-dir PATH" "Where to place resources in the Docker image"
+     :default "/home/app/lib"]]
+   tools-deps/cli-spec
+   [["-h" "--help" "show this help"]]))
+
+(defmacro *ns*-name
+  []
+  (str *ns*))
+
+(defn- usage
+  [summary]
+  (->>
+    [(format "Usage: clj -m %s [options]" (*ns*-name))
+     ""
+     "Options:"
+     summary]
+    (str/join \newline)))
+
+(defn- error-msg [errors]
+  (str "The following errors occurred while parsing your command:\n\n"
+       (str/join \newline errors)))
+
+(defn -main [& args]
+  (let [{{:keys [help
+                 image-name
+                 base-image
+                 target-dir]
+          :as options} :options
+         :as parsed-opts} (cli/parse-opts args cli-options)
+        errors (:errors parsed-opts)]
+    (cond
+      help
+      (println (usage (:summary parsed-opts)))
+      errors
+      (println (error-msg errors))
+      :else
+      (jib (-> (tools-deps/slurp-deps options)
+               (tools-deps/parse-deps-map options))
+           {:base-image base-image
+            :target-dir target-dir
+            :image-name image-name}))))

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -19,7 +19,7 @@
            (java.util.function Consumer)))
 
 (def string-array (into-array String []))
-(def target-dir "/home/app")
+(def target-dir "/app")
 
 (defn unique-base-path
   "Creates a unique string from a path by joining path elements with `-`.

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -136,7 +136,7 @@
          :as parsed-opts} (cli/parse-opts args cli-options)
         errors (:errors parsed-opts)]
     (cond
-      help
+      (or help (nil? image-name) (and (= :tar image-type) (nil? tar-file)))
       (println (usage (:summary parsed-opts)))
       errors
       (println (error-msg errors))

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -1,39 +1,62 @@
 (ns mach.pack.alpha.jib
   (:require [mach.pack.alpha.impl.tools-deps :as tools-deps]
-            [mach.pack.alpha.impl.lib-map :as lib-map]
             [clojure.string :as str]
-            [clojure.tools.cli :as cli]
-            [mach.pack.alpha.impl.elodin :as elodin])
+            [clojure.tools.cli :as cli])
   (:import (com.google.cloud.tools.jib.api Jib AbsoluteUnixPath)
-           (java.nio.file Paths)
+           (java.nio.file Paths Files LinkOption)
            (com.google.cloud.tools.jib.api LayerConfiguration
-                                           LayerConfiguration$Builder
                                            Containerizer
-                                           DockerDaemonImage)))
+                                           DockerDaemonImage
+                                           TarImage
+                                           RegistryImage
+                                           ImageReference)
+           (com.google.cloud.tools.jib.frontend CredentialRetrieverFactory)))
 
-(defn jib [{::tools-deps/keys [lib-map]} {:keys [image-name base-image target-dir]}]
+(def string-array (into-array String []))
+(def target-dir "/home/app")
+
+(defn jib [{::tools-deps/keys [paths lib-map]} {:keys [image-name image-type tar-file base-image target-dir main]}]
   (println "Building" image-name)
-  (let [libs-layer (.build (reduce (fn [acc {:keys [path] :as all}]
-                                     (.addEntry acc
-                                                (Paths/get path (into-array String []))
-                                                (AbsoluteUnixPath/get (str target-dir
-                                                                           "/"
-                                                                           (elodin/versioned-lib all)
-                                                                           ".jar"))))
-                                   (LayerConfiguration/builder)
-                                   (lib-map/lib-jars lib-map)))]
-    (-> (Jib/from base-image)
-        (.addLayer libs-layer)
-        (.setEntrypoint (into-array String ["java" "-cp" (str target-dir "/*") "clojure.main"]))
-        (.containerize (Containerizer/to (DockerDaemonImage/named image-name))))))
+  (-> (Jib/from base-image)
+      (.addLayer (into []
+                       (map #(Paths/get % string-array))
+                       (mapcat :paths (vals lib-map)))
+                 (AbsoluteUnixPath/get target-dir))
+      (.addLayer (-> (reduce (fn [acc project-path]
+                               (let [path (Paths/get project-path string-array)]
+                                 (if (Files/exists path (into-array LinkOption []))
+                                   (.addEntryRecursive acc
+                                                       path
+                                                       (AbsoluteUnixPath/get (str target-dir "/" project-path)))
+                                   acc)))
+                             (LayerConfiguration/builder)
+                             paths)
+                     (.build)))
+      (.setEntrypoint (into-array String ["java"
+                                          "-cp" (str/join ":" (cons (str target-dir "/*")
+                                                                    (map #(str target-dir "/" %) paths)))
+                                          "clojure.main" "-m" main]))
+      (.containerize (Containerizer/to (case image-type
+                                         :docker (DockerDaemonImage/named image-name)
+                                         :tar (-> (TarImage/named image-name)
+                                                  (.saveTo (Paths/get tar-file string-array)))
+                                         :registry (-> (RegistryImage/named image-name)
+                                                       (.addCredentialRetriever (-> (CredentialRetrieverFactory/forImage (ImageReference/parse image-name))
+                                                                                    (.dockerConfig)))))))))
+
+(def image-types #{:docker :registry :tar})
 
 (def ^:private cli-options
   (concat
-   [[nil "--image-name IMAGE" "Name of image to build for docker daemon"]
+   [[nil "--image-name NAME" "Name of the image"]
+    [nil "--image-type TYPE" (str "Type of the image, one of: " (str/join ", " (map name image-types)))
+     :parse-fn keyword
+     :validate [image-types (str "Supported image types: " (str/join ", " (map name image-types)))]
+     :default :docker]
+    [nil "--tar-file FILE" "Tarball file name"]
     [nil "--base-image BASE-IMAGE" "Base Docker image to use"
-     :default "openjdk:11-jre-slim"]
-    [nil "--target-dir PATH" "Where to place resources in the Docker image"
-     :default "/home/app/lib"]]
+     :default "gcr.io/distroless/java:11"]
+    ["-m" "--main SYMBOL" "Main namespace"]]
    tools-deps/cli-spec
    [["-h" "--help" "show this help"]]))
 
@@ -57,8 +80,10 @@
 (defn -main [& args]
   (let [{{:keys [help
                  image-name
+                 image-type
+                 tar-file
                  base-image
-                 target-dir]
+                 main]
           :as options} :options
          :as parsed-opts} (cli/parse-opts args cli-options)
         errors (:errors parsed-opts)]
@@ -72,4 +97,7 @@
                (tools-deps/parse-deps-map options))
            {:base-image base-image
             :target-dir target-dir
-            :image-name image-name}))))
+            :image-name image-name
+            :image-type image-type
+            :tar-file tar-file
+            :main main}))))


### PR DESCRIPTION
Adds support for building to Docker image directly via [Jib](https://github.com/GoogleContainerTools/jib). Uses the [jib-core](https://github.com/GoogleContainerTools/jib/tree/master/jib-core#adding-jib-core-to-your-build) API and supports local Docker daemon, tarball and remote registries.