### PR TITLE
Support labels, additional tags and user for Docker images

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -255,6 +255,7 @@ Options:
       --include [src:]dest                                Include file or directory, relative to container root
       --additional-tag TAG                                Additional tag for the image, e.g latest. Repeat to add multiple tags
       --label LABEL=VALUE                                 Set a label for the image, e.g. GIT_COMMIT=${CI_COMMIT_SHORT_SHA}. Repeat to add multiple labels.
+      --user USER                                         Set the user and group to run the container as. Valid formats are: user, uid, user:group, uid:gid, uid:group, user:gid
   -q, --quiet                                             Don't print a progress bar
   -v, --verbose                                           Print status of image building
   -m, --main SYMBOL                                       Main namespace

--- a/README.adoc
+++ b/README.adoc
@@ -249,7 +249,7 @@ Usage: clj -m mach.pack.alpha.jib [options]
 
 Options:
       --image-name NAME                                   Name of the image
-      --image-type TYPE        :docker                    Type of the image, one of: tar, registry, docker
+      --image-type TYPE        docker                     Type of the image, one of: tar, registry, docker
       --tar-file FILE                                     Tarball file name
       --base-image BASE-IMAGE  gcr.io/distroless/java:11  Base Docker image to use
       --include [src:]dest                                Include file or directory, relative to container root

--- a/README.adoc
+++ b/README.adoc
@@ -253,6 +253,8 @@ Options:
       --tar-file FILE                                     Tarball file name
       --base-image BASE-IMAGE  gcr.io/distroless/java:11  Base Docker image to use
       --include [src:]dest                                Include file or directory, relative to container root
+      --additional-tag TAG                                Additional tag for the image, e.g latest. Repeat to add multiple tags
+      --label LABEL=VALUE                                 Set a label for the image, e.g. GIT_COMMIT=${CI_COMMIT_SHORT_SHA}. Repeat to add multiple labels.
   -q, --quiet                                             Don't print a progress bar
   -v, --verbose                                           Print status of image building
   -m, --main SYMBOL                                       Main namespace

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -137,7 +137,9 @@
    [[nil "--image-name NAME" "Name of the image"]
     [nil "--image-type TYPE" (str "Type of the image, one of: " (str/join ", " (map name image-types)))
      :validate [image-types (str "Supported image types: " (str/join ", " (map name image-types)))]
-     :default "docker"]
+     :parse-fn keyword
+     :default :docker
+     :default-desc (name :docker)]
     [nil "--tar-file FILE" "Tarball file name"]
     [nil "--base-image BASE-IMAGE" "Base Docker image to use"
      :default "gcr.io/distroless/java:11"]
@@ -187,8 +189,7 @@
                  main]
           :as options} :options
          :as  parsed-opts} (cli/parse-opts args cli-options)
-        errors (:errors parsed-opts)
-        image-type (keyword image-type)]
+        errors (:errors parsed-opts)]
     (cond
       (or help (nil? image-name) (and (= :tar image-type) (nil? tar-file)) (nil? main))
       (println (usage (:summary parsed-opts)))

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -136,7 +136,6 @@
   (concat
    [[nil "--image-name NAME" "Name of the image"]
     [nil "--image-type TYPE" (str "Type of the image, one of: " (str/join ", " (map name image-types)))
-     :parse-fn keyword
      :validate [image-types (str "Supported image types: " (str/join ", " (map name image-types)))]
      :default "docker"]
     [nil "--tar-file FILE" "Tarball file name"]

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -123,7 +123,7 @@
     [nil "--image-type TYPE" (str "Type of the image, one of: " (str/join ", " (map name image-types)))
      :parse-fn keyword
      :validate [image-types (str "Supported image types: " (str/join ", " (map name image-types)))]
-     :default :docker]
+     :default "docker"]
     [nil "--tar-file FILE" "Tarball file name"]
     [nil "--base-image BASE-IMAGE" "Base Docker image to use"
      :default "gcr.io/distroless/java:11"]
@@ -164,8 +164,9 @@
                  verbose
                  main]
           :as options} :options
-         :as parsed-opts} (cli/parse-opts args cli-options)
-        errors (:errors parsed-opts)]
+         :as  parsed-opts} (cli/parse-opts args cli-options)
+        errors (:errors parsed-opts)
+        image-type (keyword image-type)]
     (cond
       (or help (nil? image-name) (and (= :tar image-type) (nil? tar-file)) (nil? main))
       (println (usage (:summary parsed-opts)))

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -167,7 +167,7 @@
          :as parsed-opts} (cli/parse-opts args cli-options)
         errors (:errors parsed-opts)]
     (cond
-      (or help (nil? image-name) (and (= :tar image-type) (nil? tar-file)))
+      (or help (nil? image-name) (and (= :tar image-type) (nil? tar-file)) (nil? main))
       (println (usage (:summary parsed-opts)))
       errors
       (println (error-msg errors))


### PR DESCRIPTION
Adds the following options:

* `--additional-tag TAG` for adding [additional tags](https://static.javadoc.io/com.google.cloud.tools/jib-core/0.10.0/com/google/cloud/tools/jib/api/Containerizer.html#withAdditionalTag-java.lang.String-)
* `--label LABEL=VALUE` for adding labels (implements #45 )
* `--user USER` for setting the [user to run as](https://static.javadoc.io/com.google.cloud.tools/jib-core/0.10.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#setUser-java.lang.String-)

Also minor argument handling cleanup. Don't run if `-m` is missing and remove colon from image type help text (i.e.`:docker` -> `docker`).

I ended up bundling the changes in one PR, but can split them if needed :)