### PR TITLE
Set working directory & fix error reporting for Docker builds

### DIFF
--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -127,6 +127,7 @@
         (.addLayer (-> project-dirs-layer :builder (.build)))
         (.setWorkingDirectory (AbsoluteUnixPath/get target-dir))
         (.setEntrypoint (into-array String ["java"
+                                            "-Dclojure.main.report=stderr"
                                             "-Dfile.encoding=UTF-8"
                                             "-cp" (str/join ":" (map str (mapcat :container-paths [lib-jars-layer
                                                                                                    lib-dirs-layer

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -125,6 +125,7 @@
         (.addLayer (-> lib-jars-layer :builder (.build)))
         (.addLayer (-> lib-dirs-layer :builder (.build)))
         (.addLayer (-> project-dirs-layer :builder (.build)))
+        (.setWorkingDirectory (AbsoluteUnixPath/get target-dir))
         (.setEntrypoint (into-array String ["java"
                                             "-Dfile.encoding=UTF-8"
                                             "-cp" (str/join ":" (map str (mapcat :container-paths [lib-jars-layer


### PR DESCRIPTION
A couple of fixes for issues I encountered when trying to build a Docker image that uses Kaocha to run the tests in my application.

If the Docker working directory is unset, Kaocha cannot find the `test` directory in my app directory and therefore can't run the tests. I *think* using `target-dir` as the working directory should be a sane default.

Another option would be to make it possible to pass the working directory as a CLI option, so let me know if you want a PR for that instead or in addition to this change. 

The `clojure.main.report` change makes it easier to figure out why the tests failed.