### PR TITLE
Set timestamps correctly for included class files.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -256,6 +256,7 @@ Options:
       --additional-tag TAG                                Additional tag for the image, e.g latest. Repeat to add multiple tags
       --label LABEL=VALUE                                 Set a label for the image, e.g. GIT_COMMIT=${CI_COMMIT_SHORT_SHA}. Repeat to add multiple labels.
       --user USER                                         Set the user and group to run the container as. Valid formats are: user, uid, user:group, uid:gid, uid:group, user:gid
+      --creation-time CREATION_TIME_EPOCH                 Set creation time of image in epoch seconds, e.g. $(git log -1 --pretty=format:%ct) Defaults to 0.
       --from-registry-username USER                       Set the username to use when pulling base image from registry, e.g. gitlab-ci-token.
       --from-registry-password PASSWORD                   Set the password to use when pulling base image from registry, e.g. ${CI_JOB_TOKEN}.
       --to-registry-username USER                         Set the username to use when deploying to registry, e.g. gitlab-ci-token.


### PR DESCRIPTION
Set timestamps correctly for included class files so that the Clojure system prefers them over corresponding .clj files found in JARs. This enables pack/jib to include AOT class folders on the classpath properly.

Add option to set creation time explicitly. Defaults to EPOCH 0. See https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#why-is-my-image-created-48-years-ago for why this is important.

Fixes/Enables #61 