### PR TITLE
Add new option to pass additional deps data. Equivalent to `clj -Sdeps EDN`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,7 @@ Options:
   -A ALIASES               Concatenated aliases of any kind, ex: -A:dev:mem
   -R ALIASES               Concatenated resolve-deps aliases, ex: -R:bench:1.9
   -C ALIASES               Concatenated make-classpath aliases, ex: -C:dev
-  -D, --sdeps EDN    {}    Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
+     --Sdeps EDN    {}    Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -e, --extra-path STRING  Add directory to classpath for building. Same as :extra-paths
   -h, --help               show this help
 
@@ -113,7 +113,7 @@ Usage: clj -m mach.pack.alpha.capsule [options] <path/to/output.jar>
       --system-properties STRING              space-separated list of propName=value pairs, specifying JVM System Properties which will be passed to the application. Maps to the 'System-Properties' entry in the Capsule Manifest.
       --jvm-args STRING                       space-separated list of JVM argument that will be used to launch the application (e.g "-server -Xms200m -Xmx600m"). Maps to the 'JVM-Args' entry in the Capsule Manifest.
   -e, --extra-path STRING                     add directory to classpath for building
-  -D, --sdeps EDN               {}            Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
+      --Sdeps EDN               {}            Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -M, --manifest-entry STRING                 a "Key: Value" pair that will be appended to the Capsule Manifest; useful for conveying arbitrary Manifest entries to the Capsule Manifest. Can be repeated to supply several entries.
   -h, --help                                  show this help
 ----
@@ -152,7 +152,7 @@ Usage: clj -m mach.pack.alpha.one-jar [options] <path/to/output.jar>
 Options:
   -e, --extra-path STRING                add directory to classpath for building
   -d, --deps STRING        deps.edn      deps.edn file location
-  -D, --sdeps EDN          {}            Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
+      --Sdeps EDN          {}            Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -m, --main STRING        clojure.main  Override the default main of clojure.main. You MUST use AOT compilation with this.
   -h, --help                             show this help
 
@@ -188,7 +188,7 @@ Options:
   -A ALIASES                               Concatenated aliases of any kind, ex: -A:dev:mem
   -R ALIASES                               Concatenated resolve-deps aliases, ex: -R:bench:1.9
   -C ALIASES                               Concatenated make-classpath aliases, ex: -C:dev
-  -D, --sdeps EDN          {}              Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
+      --Sdeps EDN          {}              Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -e, --extra-path STRING                  Add directory to classpath for building. Same as :extra-paths
   -h, --help                               show this help
 ----
@@ -269,7 +269,7 @@ Options:
   -A ALIASES                                              Concatenated aliases of any kind, ex: -A:dev:mem
   -R ALIASES                                              Concatenated resolve-deps aliases, ex: -R:bench:1.9
   -C ALIASES                                              Concatenated make-classpath aliases, ex: -C:dev
-  -D, --sdeps EDN              {}                         Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
+      --Sdeps EDN              {}                         Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -e, --extra-path STRING                                 Add directory to classpath for building. Same as :extra-paths
   -h, --help                                              show this help
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -56,6 +56,7 @@ Options:
   -A ALIASES               Concatenated aliases of any kind, ex: -A:dev:mem
   -R ALIASES               Concatenated resolve-deps aliases, ex: -R:bench:1.9
   -C ALIASES               Concatenated make-classpath aliases, ex: -C:dev
+  -D, --sdeps EDN    {}    Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -e, --extra-path STRING  Add directory to classpath for building. Same as :extra-paths
   -h, --help               show this help
 
@@ -112,7 +113,7 @@ Usage: clj -m mach.pack.alpha.capsule [options] <path/to/output.jar>
       --system-properties STRING              space-separated list of propName=value pairs, specifying JVM System Properties which will be passed to the application. Maps to the 'System-Properties' entry in the Capsule Manifest.
       --jvm-args STRING                       space-separated list of JVM argument that will be used to launch the application (e.g "-server -Xms200m -Xmx600m"). Maps to the 'JVM-Args' entry in the Capsule Manifest.
   -e, --extra-path STRING                     add directory to classpath for building
-  -d, --deps STRING                 deps.edn  deps.edn file location
+  -D, --sdeps EDN               {}            Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -M, --manifest-entry STRING                 a "Key: Value" pair that will be appended to the Capsule Manifest; useful for conveying arbitrary Manifest entries to the Capsule Manifest. Can be repeated to supply several entries.
   -h, --help                                  show this help
 ----
@@ -151,6 +152,7 @@ Usage: clj -m mach.pack.alpha.one-jar [options] <path/to/output.jar>
 Options:
   -e, --extra-path STRING                add directory to classpath for building
   -d, --deps STRING        deps.edn      deps.edn file location
+  -D, --sdeps EDN          {}            Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -m, --main STRING        clojure.main  Override the default main of clojure.main. You MUST use AOT compilation with this.
   -h, --help                             show this help
 
@@ -186,6 +188,7 @@ Options:
   -A ALIASES                               Concatenated aliases of any kind, ex: -A:dev:mem
   -R ALIASES                               Concatenated resolve-deps aliases, ex: -R:bench:1.9
   -C ALIASES                               Concatenated make-classpath aliases, ex: -C:dev
+  -D, --sdeps EDN          {}              Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -e, --extra-path STRING                  Add directory to classpath for building. Same as :extra-paths
   -h, --help                               show this help
 ----
@@ -266,6 +269,7 @@ Options:
   -A ALIASES                                              Concatenated aliases of any kind, ex: -A:dev:mem
   -R ALIASES                                              Concatenated resolve-deps aliases, ex: -R:bench:1.9
   -C ALIASES                                              Concatenated make-classpath aliases, ex: -C:dev
+  -D, --sdeps EDN              {}                         Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.
   -e, --extra-path STRING                                 Add directory to classpath for building. Same as :extra-paths
   -h, --help                                              show this help
 ----

--- a/src/mach/pack/alpha/impl/tools_deps.clj
+++ b/src/mach/pack/alpha/impl/tools_deps.clj
@@ -43,10 +43,16 @@
    ["-e" "--extra-path STRING" "Add directory to classpath for building. Same as :extra-paths"
     :assoc-fn (fn [m k v] (update m k conj v))
     :id ::extra]
+
+
+   ["-D" "--sdeps EDN" "Deps data to use as the last deps file to be merged by tool.deps when pulling dependencies for image. Equivalent to `clj -Sdeps EDN`."
+    :id ::sdeps
+    :parse-fn edn/read-string
+    :default "{}"]
    #_["-d" "--deps STRING" "deps.edn file location"
-    :default "deps.edn"
-    :validate [(comp (memfn exists) io/file) "deps.edn file must exist"]
-    :id ::deps-path]])
+      :default "deps.edn"
+      :validate [(comp (memfn exists) io/file) "deps.edn file must exist"]
+      :id ::deps-path]])
 
 (comment
   (require '[clojure.tools.cli :as cli])
@@ -83,8 +89,8 @@
 
 ;; opts is return of cli-opts, except ::deps-path
 (defn parse-deps-map
-  [deps-map {::keys [resolve-aliases makecp-aliases extra]}]
-  (let [deps-map (tools.deps.reader/merge-deps [(tools.deps.reader/install-deps) (config-edn) deps-map])
+  [deps-map {::keys [resolve-aliases makecp-aliases extra sdeps]}]
+  (let [deps-map (tools.deps.reader/merge-deps [sdeps (tools.deps.reader/install-deps) (config-edn) deps-map])
 
         resolve-args (tools.deps/combine-aliases deps-map resolve-aliases)
         cp-args (tools.deps/combine-aliases deps-map makecp-aliases)]

--- a/src/mach/pack/alpha/impl/tools_deps.clj
+++ b/src/mach/pack/alpha/impl/tools_deps.clj
@@ -43,9 +43,7 @@
    ["-e" "--extra-path STRING" "Add directory to classpath for building. Same as :extra-paths"
     :assoc-fn (fn [m k v] (update m k conj v))
     :id ::extra]
-
-
-   ["-D" "--sdeps EDN" "Deps data to use as the last deps file to be merged by tool.deps when pulling dependencies for image. Equivalent to `clj -Sdeps EDN`."
+   ["-D" "--sdeps EDN" "Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`."
     :id ::sdeps
     :parse-fn edn/read-string
     :default "{}"]

--- a/src/mach/pack/alpha/impl/tools_deps.clj
+++ b/src/mach/pack/alpha/impl/tools_deps.clj
@@ -43,7 +43,7 @@
    ["-e" "--extra-path STRING" "Add directory to classpath for building. Same as :extra-paths"
     :assoc-fn (fn [m k v] (update m k conj v))
     :id ::extra]
-   ["-D" "--sdeps EDN" "Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`."
+   [nil "--Sdeps EDN" "Deps data to use as the last deps map to be merged by tool.deps when pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`."
     :id ::sdeps
     :parse-fn edn/read-string
     :default "{}"]


### PR DESCRIPTION
This PR adds this parameter:

     -D, --sdeps EDN    Deps data to use as the last deps map to be merged by tool.deps when
                                   pulling dependencies at build time. Equivalent to `clj -Sdeps EDN`.

Closes #71 