### PR TITLE
Bugfix: the default `""` for extra-java-args leads to an entrypoint

### DIFF
--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -142,7 +142,8 @@
         (.addLayer (-> project-dirs-layer :builder (.build)))
         (.setWorkingDirectory (AbsoluteUnixPath/get target-dir))
         (.setEntrypoint (into-array String (concat ["java"]
-                                                   (str/split extra-java-args #"\s+")
+                                                   (when (seq extra-java-args)
+                                                     (str/split extra-java-args #"\s+"))
                                                    ["-Dclojure.main.report=stderr"
                                                     "-Dfile.encoding=UTF-8"
                                                     "-cp" (str/join ":" (map str (mapcat :container-paths [lib-jars-layer


### PR DESCRIPTION
that begins with `"java" "" ...`, thereby the following arguments like
the classpath are not processed correctly and the Docker container
exits with `Error: Could not find or load main class`.