### PR TITLE
Update latest stable sha

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,10 +25,10 @@ NOTE: This isn't infallible.  Please let me know if I break your indentation.
 
 [source,clojure]
 ----
-$ clojure -Sdeps '{:deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git" :sha "dccf2134bcf03726a9465d2b9997c42e5cd91bff"}}}' -m mach.pack.alpha.inject 'c70740ffc10805f34836da2160fa1899601fac02'
+$ clojure -Sdeps '{:deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git" :sha "dccf2134bcf03726a9465d2b9997c42e5cd91bff"}}}' -m mach.pack.alpha.inject '2d75eac719e3a0e2112958cbc23d8cbfce4690bf'
 ----
 
-TIP: Latest stable sha is `c70740ffc10805f34836da2160fa1899601fac02`.
+TIP: Latest stable sha is `2d75eac719e3a0e2112958cbc23d8cbfce4690bf`.
 
 The following examples assume you have run this.
 


### PR DESCRIPTION
When no extra args are supplied, it is necessary to use the following commit of pack.alpha so that the entrypoint is constructed correctly.

 https://github.com/juxt/pack.alpha/commit/2d75eac719e3a0e2112958cbc23d8cbfce4690bf 