### PR TITLE
Fully qualify dependency specifications

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,6 @@
         me.raynes/fs {:mvn/version "1.4.6"}
         co.paralleluniverse/capsule {:mvn/version "1.0.3"}
         org.clojure/tools.cli {:mvn/version "0.4.1"}
-        rewrite-clj {:mvn/version "0.6.0"}
+        rewrite-clj/rewrite-clj {:mvn/version "0.6.0"}
         com.google.cloud.tools/jib-core {:mvn/version "0.14.0"}
-        progrock {:mvn/version "0.1.2"}}}
+        progrock/progrock {:mvn/version "0.1.2"}}}


### PR DESCRIPTION
tools.deps 1.10.1.590 deprecates the artifact-id only style of dep specification