### PR TITLE
Fix incompatible issue by upgrading jib-core to version 0.17.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,5 +5,5 @@
         co.paralleluniverse/capsule {:mvn/version "1.0.3"}
         org.clojure/tools.cli {:mvn/version "0.4.1"}
         rewrite-clj/rewrite-clj {:mvn/version "0.6.0"}
-        com.google.cloud.tools/jib-core {:mvn/version "0.14.0"}
+        com.google.cloud.tools/jib-core {:mvn/version "0.17.0"}
         progrock/progrock {:mvn/version "0.1.2"}}}

--- a/src/mach/pack/alpha/jib.clj
+++ b/src/mach/pack/alpha/jib.clj
@@ -6,7 +6,7 @@
             [clojure.tools.cli :as cli]
             [progrock.core :as pr])
   (:import (com.google.cloud.tools.jib.api Jib)
-           (com.google.cloud.tools.jib.api.buildplan AbsoluteUnixPath)
+           (com.google.cloud.tools.jib.api.buildplan AbsoluteUnixPath ModificationTimeProvider)
            (java.nio.file Paths Files LinkOption FileSystems)
            (com.google.cloud.tools.jib.api LayerConfiguration
                                            Containerizer
@@ -19,7 +19,7 @@
                                            CredentialRetriever)
            (com.google.cloud.tools.jib.frontend CredentialRetrieverFactory)
            (com.google.cloud.tools.jib.event.events ProgressEvent TimerEvent)
-           (java.util.function Consumer BiFunction)
+           (java.util.function Consumer)
            (java.util Optional)
            (java.time Instant)))
 
@@ -74,8 +74,8 @@
                            (.getPathMatcher "glob:**.class")))
 
 (def timestamp-provider
-  (reify BiFunction
-    (apply [_ source-path destination-path]
+  (reify ModificationTimeProvider
+    (get [_this source-path _destination-path]
       (if (.matches classfile-matcher source-path)
         (Instant/ofEpochSecond 8589934591)
         LayerConfiguration/DEFAULT_MODIFICATION_TIME))))


### PR DESCRIPTION
**Environment**

- Java: openjdk 1.8.0_275
- Clojure: 1.10.1.763

**Description of the issue:**

When build docker image with _mach.pack.alpha.jib_, throw error message like follows:

```
Execution error (InvalidDefinitionException) at com.fasterxml.jackson.databind.exc.InvalidDefinitionException/from (InvalidDefinitionException.java:77).
Java 8 date/time type `java.time.Instant` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: java.util.ArrayList[0]->com.google.cloud.tools.jib.cache.LayerEntriesSelector$LayerEntryTemplate["sourceModificationTime"])
```

This is caused by _jib-core_ 0.14.0 is incompatible with some versions of its dependency _jackson_ ([here](https://github.com/GoogleContainerTools/jib/issues/2931), and [here](https://github.com/GoogleContainerTools/jib/issues/2966)), which is fixed in [jib version 0.17.0](https://github.com/GoogleContainerTools/jib/blob/master/jib-core/CHANGELOG.md#0170)

**The solution:**

Upgrade jib-core to version 0.17.0 solve this problem.

Thanks.