### PR TITLE
Update tools.deps to support new features and keywords, e.g. :git/sha

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/tools.deps.alpha {:mvn/version "0.7.541"}
+ :deps {org.clojure/tools.deps.alpha {:mvn/version "0.12.1076"}
         org.slf4j/slf4j-nop {:mvn/version "1.6.2"}
         me.raynes/fs {:mvn/version "1.4.6"}
         co.paralleluniverse/capsule {:mvn/version "1.0.3"}

--- a/src/mach/pack/alpha/impl/tools_deps.clj
+++ b/src/mach/pack/alpha/impl/tools_deps.clj
@@ -7,9 +7,12 @@
     [clojure.string :as string]
 
     [clojure.tools.deps.alpha :as tools.deps]
-    [clojure.tools.deps.alpha.reader :as tools.deps.reader]
     ;; Lazy way of loading extensions
-    [clojure.tools.deps.alpha.script.make-classpath])
+    [clojure.tools.deps.alpha.extensions.deps]
+    [clojure.tools.deps.alpha.extensions.git]
+    [clojure.tools.deps.alpha.extensions.local]
+    [clojure.tools.deps.alpha.extensions.maven]
+    [clojure.tools.deps.alpha.extensions.pom])
   (:import
     [java.io File]))
 
@@ -88,7 +91,7 @@
 ;; opts is return of cli-opts, except ::deps-path
 (defn parse-deps-map
   [deps-map {::keys [resolve-aliases makecp-aliases extra sdeps]}]
-  (let [deps-map (tools.deps.reader/merge-deps [sdeps (tools.deps.reader/install-deps) (config-edn) deps-map])
+  (let [deps-map (tools.deps/merge-edns [sdeps (tools.deps/root-deps) (config-edn) deps-map])
 
         resolve-args (tools.deps/combine-aliases deps-map resolve-aliases)
         cp-args (tools.deps/combine-aliases deps-map makecp-aliases)]
@@ -99,7 +102,7 @@
 
 (defn slurp-deps
   [_]
-  (tools.deps.reader/slurp-deps (io/file "deps.edn")))
+  (tools.deps/slurp-deps (io/file "deps.edn")))
 
 (defn make-classpath
   [{::keys [lib-map paths]}]


### PR DESCRIPTION
I have a project which still uses `pack.alpha` to create build artifacts; unfortunately the project has now acquired a dependency that uses the new `:git/sha` key, and not the old `:sha` key.

This causes pack.alpha to choke, expecting a `:sha` key to be defined.

I have forked the repo and hacked together this fix for SKINNY jars only.  I suspect similar changes would need to occur to support the other types of build.  This PR is not complete, but the patches work well enough for me to buy me some time before migrating to tools.build / `uber`.  I offer them in this draft PR as they may be instructive to others.

This PR updates the skinny jar functionality ONLY to use the latest `tools.deps.alpha`, and it updates the code to use the corresponding API changes.

Specifically the definitions for `clojure.tools.deps.alpha.reader/merge-deps` `install-deps` and `slurp-deps` have now moved; so we now use their new names.

Additionally the namespace which was being pulled into load extensions has now been moved/removed, so I've inlined all the current extensions explicitly.