### PR TITLE
Update help hint in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ Add this alias to your project:
 ----
 
 Then you can invoke it with `clj -T:pack`.
-To see usage information, use `clojure -A:deps -T:pack help/dir`
+To see usage information, use `clojure -A:deps -T:pack help/doc`.
 
 == Features
 


### PR DESCRIPTION
The command that lists the api functions plus docstrings is `help/doc` not `help/dir` (which lists only the symbols).