### PR TITLE
A couple of tweaks

### DIFF
--- a/src/juxt/pack/impl/lib_map.clj
+++ b/src/juxt/pack/impl/lib_map.clj
@@ -30,4 +30,5 @@
   [path]
   (cond
     (file-ext? (io/file path) "jar") :jar
-    (.isDirectory (io/file path)) :dir))
+    (.isDirectory (io/file path)) :dir
+    :else nil))

--- a/src/juxt/pack/one_jar.clj
+++ b/src/juxt/pack/one_jar.clj
@@ -101,14 +101,17 @@
                 lib-name
                 (let [coordinate (assoc (get-in basis [:libs lib-name])
                                         :lib lib-name
-                                        :path root)]
-                  (case (lib-map/classify root)
+                                        :path root)
+                      classification (lib-map/classify root)]
+                  (assert classification
+                          (format "Cannot classify path: %s. This is usually a bug in either the project or library deps.edn. The following var was nil:" root))
+                  (case classification
                     :jar {:input (io/input-stream root)
                           :path ["lib" (elodin/jar-name coordinate)]}
                     :dir {:paths (vfs/files-path (file-seq (io/file root)) (io/file root))
                           :path ["lib" (format "%s.jar" (elodin/directory-name coordinate))]})))))
           (:classpath-roots basis))
-        
+
         [{:path [".version"], :input (io/input-stream (io/resource "juxt/pack/bootstrap/onejar/resources/.version"))} {:path ["doc" "one-jar-license.txt"], :input (io/input-stream (io/resource "juxt/pack/bootstrap/onejar/resources/doc/one-jar-license.txt"))}]
         (let [root (.toFile bootstrap-p)]
           (vfs/files-path

--- a/src/juxt/pack/one_jar.clj
+++ b/src/juxt/pack/one_jar.clj
@@ -21,8 +21,7 @@
         compiler  (or (ToolProvider/getSystemJavaCompiler)
                       (throw (Exception. "The java compiler is not working. Please make sure you use a JDK!")))]
     (with-open [file-mgr (.getStandardFileManager compiler diag-coll nil nil)]
-      (let [file-mgr (.getStandardFileManager compiler diag-coll nil nil)
-            opts (->> ["-d"  (.getPath tgt)]
+      (let [opts (->> ["-d"  (.getPath tgt)]
                       (concat options)
                       (into-array String)
                       Arrays/asList)


### PR DESCRIPTION
Two kind of separate fixes (I suggest rebasing when merging), see commit messages:

* Remove wrong file-mgr binding in javac code
    
    It is set right above already within with-open.

* Fail writing a jar when a root path cannot be classified
    
    This will drastically improve the debugging of bugs in code base or libraries. The new output of the
    command looks like:
    
    `clojure -T:build one-jar :jar-file \"target/foo.jar\"`
    
    ```
    Execution error (AssertionError) at juxt.pack.one-jar/write-jar$fn (one_jar.clj:105).
    Assert failed: Cannot classify path: /path/to/.gitlibs/libs/foo/bar/sha/resources. This is usually a
    bug in either the project or library deps.edn. The following var was nil:
    classification
    ```