### PR TITLE
jib uses clojure.tools.build.api/resolve-path if available

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
  :deps {org.clojure/tools.deps.alpha {:mvn/version "0.12.1076"}
         ;; TODO: Migrate to clj-commons
         me.raynes/fs {:mvn/version "1.4.6"}
-        com.google.cloud.tools/jib-core {:mvn/version "0.21.0"}}
+        com.google.cloud.tools/jib-core {:mvn/version "0.21.0"}
+        borkdude/dynaload {:mvn/version "0.3.5"}}
  
  :aliases {:pack {:deps {io.github.juxt/pack {:local/root "."}}
                   :ns-default juxt.pack.cli.api}


### PR DESCRIPTION
Closes #114 

This optionally supports the `clojure.tools.build.api/resolve-path` function if available, allowing `juxt.pack.jib` to support `clojure.tools.build.api/*project-root*`

This seems like it would be a common need for projects using `clojure.tools.build` in a monorepo.

This introduces a dependency on [borkdude.dynaload](https://github.com/borkdude/dynaload).

Please let me know if I can make any improvements/changes 🙇🏻 