### PR TITLE
Bump jib to 0.23.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,8 @@
  :deps {org.clojure/tools.deps {:mvn/version "0.17.1297"}
         ;; TODO: Migrate to clj-commons
         me.raynes/fs {:mvn/version "1.4.6"}
-        com.google.cloud.tools/jib-core {:mvn/version "0.21.0"}}
- 
+        com.google.cloud.tools/jib-core {:mvn/version "0.23.0"}}
+
  :aliases {:pack {:deps {io.github.juxt/pack {:local/root "."}}
                   :ns-default juxt.pack.cli.api}
            :library {:exec-args {:path "pack-library.jar"}


### PR DESCRIPTION
This version of jib includes support for newer OCI manifests, prior to this update using some images would result in errors like:

```
Tried to pull image manifest for
gcr.io/distroless/java17-debian11:latest but failed because: Manifest with tag 'latest' has media type

'application/vnd.oci.image.index.v1+json', but client accepts 'application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json'.
```