### PR TITLE
Add option to set platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 .cpcache
 .nrepl-port
+.calva
+.clj-kondo
+.lsp

--- a/src/juxt/pack/api.clj
+++ b/src/juxt/pack/api.clj
@@ -20,6 +20,8 @@
                 :libs - built-in layer, libs from basis
                 instance of Jib FileEntriesLayer
               default = [:libs :paths]
+    :platforms - optional, a set of keywords of the form :<os>/<architecture>
+                 e.g. #{:linux/amd64 :linux/arm64}
 
     Runtime:
     :base-image - base docker image to use, default = gcr.io/distroless/java:11

--- a/src/juxt/pack/jib.clj
+++ b/src/juxt/pack/jib.clj
@@ -4,7 +4,7 @@
             [juxt.pack.impl.elodin :as elodin]
             [clojure.string :as str])
   (:import (com.google.cloud.tools.jib.api Jib JibContainerBuilder)
-           (com.google.cloud.tools.jib.api.buildplan AbsoluteUnixPath ModificationTimeProvider FileEntriesLayer)
+           (com.google.cloud.tools.jib.api.buildplan AbsoluteUnixPath FileEntriesLayer ModificationTimeProvider Platform)
            (java.nio.file Paths Files LinkOption FileSystems)
            (com.google.cloud.tools.jib.api Containerizer
                                            DockerDaemonImage
@@ -184,6 +184,7 @@
 
            volumes
            layers
+           platforms
 
            creation-time
            user]
@@ -226,7 +227,10 @@
                                            #(str (get container-roots %))
                                            (:classpath-roots basis)))
                                "clojure.main"]
-                              (-> basis :argmap :main-opts))))
+                              (-> basis :classpath-args :main-opts))))
+        (cond-> (seq platforms)
+          (.setPlatforms
+           (into #{} (map #(Platform. (name %) (namespace %)) platforms))))
         (.containerize
           (add-additional-tags
             (make-containerizer


### PR DESCRIPTION
Supports the use of a new `:platforms` key to allow multi arch builds:

For example an image built with the following would support intel and macos arm64:

```
:platforms #{:linux/amd64 :linux/arm64}
```

Note though, jib has some limitations with multi-arch support, e.g. pushing multi arch images to `:image-type` `:docker` doesn't appear to be supported (yet at least).